### PR TITLE
Set DEFAULT_BRANCH env variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         DEFAULT_BUMP: ${{ inputs.default-bump }}
         RELEASE_BRANCHES: "main"
+        DEFAULT_BRANCH: "main"
         WITH_V: "true"
         DRY_RUN: "true"
     - name: List Release


### PR DESCRIPTION
https://github.com/vivantehealth/iap-http-loadbalancer-module/actions/runs/3846903920/jobs/6552759493

If default branch is not set in non-PR commits, the release actions will fail.