### PR TITLE
Allowing Releases to contain Artifacts to Upload

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,14 @@ inputs:
     required: false
     description: 'Which git sha to use for the floating tags. Useful for CD workflows where the main branch is pushed just prior to tagging'
     default: ''
+  artifacts:
+    description: 'Path of artifacts to upload. comma separated list and supports glob patterns'
+    required: false
+    default: ''
+  artifactsContentType:
+    description: 'The content type of the artifact. Defaults to raw'
+    required: false
+    default: 'raw'
 # Output the major version
 outputs:
   major:
@@ -146,6 +154,8 @@ runs:
       uses: ncipollo/release-action@v1
       if: steps.tag.outputs.part != 'none'
       with:
+        artifacts: ${{ inputs.artifacts }}
+        artifactsContentType: ${{ inputs.artifactContentType }}
         body: ${{ github.event.head_commit.message }}
         tag: ${{ steps.tag.outputs.new_tag }}
         generateReleaseNotes: true

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
   artifactContentType:
     description: 'The content type of the artifact. Defaults to raw'
     required: false
-    default: 'raw'
+    default: ''
 # Output the major version
 outputs:
   major:

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: 'Path of artifacts to upload. comma separated list and supports glob patterns'
     required: false
     default: ''
-  artifactsContentType:
+  artifactContentType:
     description: 'The content type of the artifact. Defaults to raw'
     required: false
     default: 'raw'
@@ -155,7 +155,7 @@ runs:
       if: steps.tag.outputs.part != 'none'
       with:
         artifacts: ${{ inputs.artifacts }}
-        artifactsContentType: ${{ inputs.artifactContentType }}
+        artifactContentType: ${{ inputs.artifactContentType }}
         body: ${{ github.event.head_commit.message }}
         tag: ${{ steps.tag.outputs.new_tag }}
         generateReleaseNotes: true


### PR DESCRIPTION
The `ncipollo/release-action` GitHub Action provides the ability for us to attach release objects to the GH release itself. I've basically added the `artifacts` and `artifactContentType` inputs to our internal action so we can reuse `ncipollo`'s.

The defaults match the defaults of his action, so everything should perform the same as it does today.