### PR TITLE
Pass --notes-start-tag explicitly for deterministic changelog diff

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,7 @@ runs:
         fi
 
         LATEST_TAG=$(git tag --list "${PREFIX}[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
+        echo "previous_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
         COMMIT_MSG=$(git log -1 --format=%B)
         LATEST_TAG="$LATEST_TAG" COMMIT_MSG="$COMMIT_MSG" \
           go run -C "$ACTION_PATH" . "$INPUT_DEFAULT_BUMP" "$INPUT_V_PREFIX"
@@ -81,9 +82,14 @@ runs:
         INPUT_TAG: ${{ steps.semver.outputs.new_tag }}
         INPUT_TARGET: ${{ github.sha }}
         INPUT_ARTIFACTS: ${{ inputs.artifacts }}
+        INPUT_PREV_TAG: ${{ steps.semver.outputs.previous_tag }}
       run: |
         shopt -s nullglob
         ARGS=(--generate-notes --target "$INPUT_TARGET")
+
+        if [[ -n "$INPUT_PREV_TAG" ]]; then
+          ARGS+=(--notes-start-tag "$INPUT_PREV_TAG")
+        fi
 
         if [[ -n "$INPUT_ARTIFACTS" ]]; then
           IFS=',' read -ra FILES <<< "$INPUT_ARTIFACTS"


### PR DESCRIPTION
## Summary
- Emit `previous_tag` from the calculate step and pass it to `gh release create --notes-start-tag` so the auto-generated \"Full Changelog: prev...new\" link is deterministic
- First-ever release case (no prior tag) is handled by the `-n` guard — the flag is omitted and GitHub falls back to default behavior

## Why
GitHub's auto-detection for `--generate-notes` picks the "last published full Release". It works today but breaks silently if anyone attaches a Release to a floating tag (e.g. `v1`), or if GitHub changes the heuristic. We already know the previous tag — passing it through removes the ambiguity.

## Test plan
- [ ] Verify the next release on `main` produces a changelog with the correct `vX.Y.Z...vA.B.C` link

🤖 Generated with [Claude Code](https://claude.com/claude-code)