### PR TITLE
Add gomod Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot only tracked github-actions in this repo. Add a gomod block (directory "/", weekly) so Go module updates are also tracked. Config-only change; no dependency bumps.